### PR TITLE
Update lib.rs to make it `no_std`-friendly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(fn_traits, unboxed_closures, const_extern_fn)]
+#![no_std]
 
 //! # Overloadf
 //!


### PR DESCRIPTION
Since everything happen in `overloadf_derive` (and especially since it _already_ expands to `core::ops::Fn*` implementations and not to std ones), there is no point keeping no-std environments away from this cool crate. Although I'm still a fairly new beginner to Rust, I don't think two lines of public re-exports would break with a little innocent `#![no_std]` right ? (Or is there still some stuff expanding to std calls that I didn't see ?)